### PR TITLE
Fix workflow for Vite: use dist/ instead of build/

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to S3
-        run: aws s3 sync build/ s3://${{ steps.outputs.outputs.bucket }} --delete
+        run: aws s3 sync dist/ s3://${{ steps.outputs.outputs.bucket }} --delete
 
       - name: Invalidate CloudFront cache
         run: aws cloudfront create-invalidation \


### PR DESCRIPTION
This pull request makes a small change to the deployment workflow, updating the source directory for the S3 sync step from `build/` to `dist/`. This ensures that the correct output directory is used during deployment.